### PR TITLE
Add RedisEndpoint.* attributes to CacheCluster

### DIFF
--- a/resources/elasti_cache/cache_cluster.go
+++ b/resources/elasti_cache/cache_cluster.go
@@ -39,6 +39,14 @@ var CacheCluster = Resource{
 		"ConfigurationEndpoint.Port": Schema{
 			Type: ValueString,
 		},
+		
+		"RedisEndpoint.Address": Schema {
+			Type: ValueString,
+		},
+		
+		"RedisEndpoint.Port": Schema {
+			Type: ValueString,
+		},
 	},
 
 	// Name


### PR DESCRIPTION
`Fn::GetAtt` on a AWS::ElastiCache::CacheCluster can also return:

* `RedisEndpoint.Address`
* `RedisEndpoint.Port`